### PR TITLE
aiff on timeline now correct

### DIFF
--- a/Slide-by-Side_creator/creator/Form1.cs
+++ b/Slide-by-Side_creator/creator/Form1.cs
@@ -798,7 +798,12 @@ namespace formNamespace
             sh.addSoundTrackToSlideshow(selectedTrack);
 
             //update duration of show
-            showDuration = showDuration + selectedTrack.Duration;
+            //reset duration first
+            showDuration = 0;
+            foreach (SoundTrack x in sh.SlideshowSoundTrackList)
+            {
+                showDuration = showDuration + x.Duration;
+            }
 
             //update panel
             updateMusicPanel();
@@ -812,6 +817,12 @@ namespace formNamespace
             else
             {
                 instructionsTextBox.Text = "Awesome! Be sure to add some images to your timeline as well!";
+            }
+
+            ///DEBUGGING////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+            foreach (SoundTrack x in sh.SlideshowSoundTrackList)
+            {
+                Console.WriteLine(x.Duration + "\n\n");
             }
         }
 

--- a/Slide-by-Side_creator/creator/SlideShowHandler.cs
+++ b/Slide-by-Side_creator/creator/SlideShowHandler.cs
@@ -219,8 +219,38 @@ namespace formNamespace
         // Add soundtrack to show
         public void addSoundTrackToSlideshow(SoundTrack track)
         {
+            //Re-open track and ensure correct duration before adding to timeline
+
+            SoundTrack newShowTrack = track;
+            //set its path name
+
+            newShowTrack.Path = track.Path;
+
+            //open sound file to get duration
+            soundTrackPlayer.Open(new Uri(track.Path, UriKind.Relative)); //use path to get duration
+
+            int counter = 0;
+            //NOTE: This wait is to ensure successful opening of sound file
+            //time out if it took more than 2 seconds
+            while ((soundTrackPlayer.NaturalDuration.HasTimeSpan) == false && (counter < 20))
+            {
+                Thread.Sleep(100);
+                counter++;
+            }
+
+            //Set the duration of the track object
+            if (soundTrackPlayer.NaturalDuration.HasTimeSpan == true)
+            {
+                newShowTrack.Duration = (int)(soundTrackPlayer.NaturalDuration.TimeSpan.TotalSeconds); //get duration in seconds
+                soundTrackPlayer.Close();
+            }
+            else
+            {
+                Console.WriteLine("SOUNDTRACK ERROR: COULD NOT SET DURATION ON ADD TO SHOW\n\n");
+            }
+
             //add to organized slideshow list
-            SlideshowSoundTrackList.Add(track);
+            SlideshowSoundTrackList.Add(newShowTrack);
         }
 
         public void removeSoundTrackFromSlideshow(SoundTrack track)


### PR DESCRIPTION
-aiff duration was not getting copied properly previously.

-additional checks were put into place to ensure durations are correct going in to the time line.